### PR TITLE
Refactor bot structure and add slash command support

### DIFF
--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -1,43 +1,52 @@
-# cogs/fun.py
+"""Fun commands cog."""
+
+from __future__ import annotations
+
+import asyncio
+import random
+
 import discord
 from discord.ext import commands
-import random
-import asyncio
+
 
 class Fun(commands.Cog):
-    def __init___(self,bot):
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
     # coin flip
-    @commands.command(name="flip", help="Flips a coin!")
-    async def flip(self, ctx):
-        message = await ctx.send("Flipping a coin...") # initial message
-        await asyncio.sleep(3) # 2 second delay before simulating flip
-
+    @commands.hybrid_command(description="Flip a coin!")
+    async def flip(self, ctx: commands.Context) -> None:
+        message = await ctx.send("Flipping a coin...")
+        await asyncio.sleep(3)
         result = random.choice(["Heads", "Tails"])
-        await message.edit(content=f"{result}!") # edit message with result
+        await message.edit(content=f"{result}!")
 
     # rock, paper, scissors
-    @commands.command(name="rps", help="Play rock,paper,scissors with the bot")
-    async def rps(self, ctx, user_choice: str):
+    @commands.hybrid_command(description="Play rock, paper, scissors with the bot")
+    async def rps(self, ctx: commands.Context, user_choice: str) -> None:
         choices = ["rock", "paper", "scissors"]
         bot_choice = random.choice(choices)
 
         if user_choice.lower() not in choices:
             await ctx.send("Please choose rock, paper, or scissors!")
             return
-        
+
         if user_choice.lower() == bot_choice:
             result = "It's a tie!"
-        elif (user_choice.lower() == 'rock' and bot_choice == 'scissors') or \
-            (user_choice.lower() == 'paper' and bot_choice == 'rock') or \
-            (user_choice.lower() == 'scissors' and bot_choice == 'paper'):
-            result = 'You win!'
+        elif (
+            (user_choice.lower() == "rock" and bot_choice == "scissors")
+            or (user_choice.lower() == "paper" and bot_choice == "rock")
+            or (user_choice.lower() == "scissors" and bot_choice == "paper")
+        ):
+            result = "You win!"
         else:
-            result = 'You lose!'
+            result = "You lose!"
 
-        await ctx.send(f"You chose {user_choice}, I chose {bot_choice}, {result}.")
+        await ctx.send(
+            f"You chose {user_choice}, I chose {bot_choice}, {result}."
+        )
 
-    
-async def setup(bot):
+
+async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(Fun(bot))
+

--- a/cogs/math.py
+++ b/cogs/math.py
@@ -1,20 +1,25 @@
-# cogs/math.py
+"""Mathematics related commands."""
+
+from __future__ import annotations
+
 import discord
 from discord.ext import commands
 
+
 class Math(commands.Cog):
-    def __init__(self,bot):
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
-
     # perform calculation
-    @commands.command(name="calc", help="Calculate mathematical expression.")
-    async def calculate(self, ctx, *, expression: str):
+    @commands.hybrid_command(name="calc", description="Calculate a mathematical expression")
+    async def calculate(self, ctx: commands.Context, *, expression: str) -> None:
         try:
             result = eval(expression)
-            await ctx.send(f"the result of `{expression}` is `{result}`!")
-        except Exception as e:
-            await ctx.send(f"Error: {str(e)}")
+            await ctx.send(f"The result of `{expression}` is `{result}`!")
+        except Exception as exc:
+            await ctx.send(f"Error: {exc}")
 
-async def setup(bot):
+
+async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(Math(bot))
+

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1,63 +1,86 @@
-# cogs/moderation.py
-import discord
-from discord.ext import commands
+"""Moderation related commands."""
+
+from __future__ import annotations
+
 from datetime import timedelta
 
+import discord
+from discord.ext import commands
+
+
 class Moderation(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
     # purge messages
-    @commands.command(name="purge", help="Deletes a specified number of messages.")
-    @commands.has_permissions(manage_messages = True)
-    async def purge(self, ctx, amount: int):
+    @commands.hybrid_command(name="purge", description="Delete a specified number of messages")
+    @commands.has_permissions(manage_messages=True)
+    async def purge(self, ctx: commands.Context, amount: int) -> None:
         try:
             await ctx.channel.purge(limit=amount + 1)
-            await ctx.send(f"Deleted {amount} messages.", delete_after = 5)
-
-        except Exception as e:
-            await ctx.send(f"Failed to delete messages. Error: {str(e)}")
+            await ctx.send(f"Deleted {amount} messages.", delete_after=5)
+        except Exception as exc:
+            await ctx.send(f"Failed to delete messages. Error: {exc}")
 
     # timeout user (simple version)
-    @commands.command(name="timeout", help="Timeout a user for a specified duration (in minutes)")
-    @commands.has_permissions(moderate_members = True)
-    async def timeout(self, ctx, member: discord.Member, minutes: int, reason: str = "None"):
+    @commands.hybrid_command(
+        name="timeout",
+        description="Timeout a user for a specified duration (in minutes)",
+    )
+    @commands.has_permissions(moderate_members=True)
+    async def timeout(
+        self,
+        ctx: commands.Context,
+        member: discord.Member,
+        minutes: int,
+        reason: str = "None",
+    ) -> None:
         if not member:
             await ctx.send("You must mention a user to timeout!")
+            return
 
-        else:
-            try:
-                duration = timedelta(minutes=minutes)
-                await member.timeout(duration)
-                await ctx.send(f"{member.name} has been timed out for {minutes} minute(s). Reason: {reason}!")
-            except Exception as e:
-                await ctx.send(f"Failed to timeout {member.name}. Error: {str(e)}")
+        try:
+            duration = timedelta(minutes=minutes)
+            await member.timeout(duration, reason=reason)
+            await ctx.send(
+                f"{member.name} has been timed out for {minutes} minute(s). Reason: {reason}!"
+            )
+        except Exception as exc:
+            await ctx.send(f"Failed to timeout {member.name}. Error: {exc}")
 
     # kick user
-    @commands.command(name="kick", help="Kick a user from the server.")
-    @commands.has_permissions(kick_members = True)
-    async def kick(self, ctx, member: discord.Member, reason: str = "None"):
+    @commands.hybrid_command(name="kick", description="Kick a user from the server")
+    @commands.has_permissions(kick_members=True)
+    async def kick(
+        self, ctx: commands.Context, member: discord.Member, reason: str = "None"
+    ) -> None:
         if not member:
             await ctx.send("You must mention a user to kick!")
-        else:
-            try:
-                await member.kick(reason=reason)
-                await ctx.send(f"{member.name} has been kicked!")
-            except Exception as e:
-                await ctx.send(f"Failed to kick {member.name}. Reason: {str(e)}")
-    
-    # ban member
-    @commands.command(name="ban", help="Ban a user from the server")
-    @commands.has_permissions(ban_members = True)
-    async def ban(self, ctx, member: discord.Member, reason: str = "None"):
-        if not member:
-            await ctx.send("You must mention a user to kick!")
-        else:
-            try:
-                await member.ban(reason=reason)
-                await ctx.send(f"{member.name} has been banned!")
-            except Exception as e:
-                await ctx.send(f"Failed to ban {member.name}. Reason: {str(e)}")
+            return
 
-async def setup(bot):
+        try:
+            await member.kick(reason=reason)
+            await ctx.send(f"{member.name} has been kicked!")
+        except Exception as exc:
+            await ctx.send(f"Failed to kick {member.name}. Reason: {exc}")
+
+    # ban member
+    @commands.hybrid_command(name="ban", description="Ban a user from the server")
+    @commands.has_permissions(ban_members=True)
+    async def ban(
+        self, ctx: commands.Context, member: discord.Member, reason: str = "None"
+    ) -> None:
+        if not member:
+            await ctx.send("You must mention a user to kick!")
+            return
+
+        try:
+            await member.ban(reason=reason)
+            await ctx.send(f"{member.name} has been banned!")
+        except Exception as exc:
+            await ctx.send(f"Failed to ban {member.name}. Reason: {exc}")
+
+
+async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(Moderation(bot))
+

--- a/main.py
+++ b/main.py
@@ -1,44 +1,78 @@
+"""Main entry point for the bot.
+
+This file defines a subclass of :class:`commands.Bot` which loads all
+extensions on start and ensures both prefix and slash commands are
+available.  All cogs are loaded during ``setup_hook`` so they are ready
+before the bot connects to Discord.
+"""
+
+from __future__ import annotations
+
+import os
 import discord
 from discord.ext import commands
 from dotenv import load_dotenv
-import os
 
-load_dotenv() # Load environment variables from .env file
-# test
 
-TOKEN = os.getenv('DISCORD_TOKEN')
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
 
-intents = discord.Intents.all()
-bot = commands.Bot(command_prefix="!", intents=intents)
+load_dotenv()  # Load environment variables from .env file
+TOKEN = os.getenv("DISCORD_TOKEN")
+DEFAULT_PREFIX = "!"
+
+
+class SyaaBot(commands.Bot):
+    """Bot subclass that handles cog loading and command syncing."""
+
+    def __init__(self) -> None:
+        intents = discord.Intents.all()
+        super().__init__(
+            command_prefix=commands.when_mentioned_or(DEFAULT_PREFIX),
+            intents=intents,
+        )
+
+    async def setup_hook(self) -> None:
+        """Load extensions and sync the application command tree."""
+
+        # Load available extensions
+        for extension in [
+            "cogs.math",
+            "cogs.fun",
+            "cogs.moderation",
+            "cogs.actions",
+        ]:
+            try:
+                await self.load_extension(extension)
+            except Exception as exc:  # pragma: no cover - log for debugging
+                print(f"Failed to load {extension}: {exc}")
+
+        # Sync slash commands
+        await self.tree.sync()
+
+
+bot = SyaaBot()
+
 
 @bot.event
-async def on_ready():
-    print(f"{bot.user.name} has logged in!")
-    
-    # load cogs
-    try:
-        await bot.load_extension("cogs.math")
-        await bot.load_extension("cogs.fun")
-        await bot.load_extension("cogs.moderation")
-        await bot.load_extension("cogs.actions")
-        await bot.load_extension("cogs.roleplay")
-        await bot.load_extension("cogs.chatbot")
-        print("cog(s) has loaded successfully")
+async def on_ready() -> None:
+    """Announce successful login and set presence."""
 
-    except Exception as e:
-        print(f"failed to load cog(s): {str(e)}")
+    print(f"{bot.user} has logged in!")
 
-    # rich presence
     activity = discord.Game(name="with Unperson!")
-    '''discord.Activity(type=discord.ActivityType.listening, name="music")
-    discord.Activity(type=discord.ActivityType.watching, name="anime")'''
     await bot.change_presence(status=discord.Status.online, activity=activity)
 
-    # sync slash commands
-    await bot.tree.sync()
 
-    
-@bot.tree.command()
-async def prefix(interaction: discord.Interaction):
-    await interaction.response.send_message(f"The current bot prefix is: {prefix}")
+@bot.tree.command(description="Show the current bot prefix")
+async def prefix(interaction: discord.Interaction) -> None:
+    """Slash command to display the configured prefix."""
+
+    await interaction.response.send_message(
+        f"The current bot prefix is: {DEFAULT_PREFIX}"
+    )
+
+
 bot.run(TOKEN)
+


### PR DESCRIPTION
## Summary
- refactor main entry to subclass `commands.Bot` and load cogs at startup
- convert all commands into hybrid commands (prefix + slash)
- add asynchronous Tenor GIF fetching and shared helper for action embeds
- rework fun, math and moderation cogs for structured layout and type hints

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689ad83229848320b4bae9f6b54e393a