### PR TITLE
Add persistent RPS stats and leaderboard command

### DIFF
--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -8,6 +8,8 @@ import random
 import discord
 from discord.ext import commands
 
+from .storage import get_leaderboard, get_user_stats, record_loss, record_win
+
 
 class Fun(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
@@ -31,6 +33,8 @@ class Fun(commands.Cog):
             await ctx.send("Please choose rock, paper, or scissors!")
             return
 
+        guild_id = ctx.guild.id if ctx.guild else 0
+
         if user_choice.lower() == bot_choice:
             result = "It's a tie!"
         elif (
@@ -39,14 +43,43 @@ class Fun(commands.Cog):
             or (user_choice.lower() == "scissors" and bot_choice == "paper")
         ):
             result = "You win!"
+            record_win(guild_id, ctx.author.id)
         else:
             result = "You lose!"
+            record_loss(guild_id, ctx.author.id)
 
         await ctx.send(
-            f"You chose {user_choice}, I chose {bot_choice}, {result}."
+            f"You chose {user_choice}, I chose {bot_choice}, {result}.",
         )
+
+    @commands.hybrid_command(
+        description="Show RPS stats for a user or this server's leaderboard"
+    )
+    async def rpsstats(
+        self, ctx: commands.Context, member: discord.Member | None = None
+    ) -> None:
+        guild_id = ctx.guild.id if ctx.guild else 0
+
+        if member is not None:
+            wins, losses = get_user_stats(guild_id, member.id)
+            await ctx.send(
+                f"{member.display_name} has {wins} wins and {losses} losses in RPS."
+            )
+            return
+
+        leaderboard = get_leaderboard(guild_id)
+        if not leaderboard:
+            await ctx.send("No RPS games have been played yet!")
+            return
+
+        lines = []
+        for index, (user_id, wins, losses) in enumerate(leaderboard, start=1):
+            user = ctx.guild.get_member(user_id) if ctx.guild else self.bot.get_user(user_id)
+            name = user.display_name if user else f"User {user_id}"
+            lines.append(f"{index}. {name} - {wins}W/{losses}L")
+
+        await ctx.send("RPS Leaderboard:\n" + "\n".join(lines))
 
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(Fun(bot))
-

--- a/cogs/storage.py
+++ b/cogs/storage.py
@@ -1,0 +1,87 @@
+"""Simple storage layer for RPS stats using SQLite."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import List, Tuple
+
+DB_PATH = Path(__file__).with_name("rps_stats.sqlite3")
+
+
+def init_db() -> None:
+    """Initialise the database if it doesn't exist."""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS rps_stats (
+                guild_id INTEGER,
+                user_id INTEGER,
+                wins INTEGER DEFAULT 0,
+                losses INTEGER DEFAULT 0,
+                PRIMARY KEY (guild_id, user_id)
+            )
+            """
+        )
+        conn.commit()
+
+
+def record_win(guild_id: int, user_id: int) -> None:
+    """Record a win for the given user."""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            """
+            INSERT INTO rps_stats (guild_id, user_id, wins, losses)
+            VALUES (?, ?, 1, 0)
+            ON CONFLICT(guild_id, user_id)
+            DO UPDATE SET wins = wins + 1
+            """,
+            (guild_id, user_id),
+        )
+        conn.commit()
+
+
+def record_loss(guild_id: int, user_id: int) -> None:
+    """Record a loss for the given user."""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            """
+            INSERT INTO rps_stats (guild_id, user_id, wins, losses)
+            VALUES (?, ?, 0, 1)
+            ON CONFLICT(guild_id, user_id)
+            DO UPDATE SET losses = losses + 1
+            """,
+            (guild_id, user_id),
+        )
+        conn.commit()
+
+
+def get_user_stats(guild_id: int, user_id: int) -> Tuple[int, int]:
+    """Return wins and losses for ``user_id`` in ``guild_id``."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.execute(
+            "SELECT wins, losses FROM rps_stats WHERE guild_id = ? AND user_id = ?",
+            (guild_id, user_id),
+        )
+        row = cursor.fetchone()
+        return (row[0], row[1]) if row else (0, 0)
+
+
+def get_leaderboard(guild_id: int, limit: int = 10) -> List[Tuple[int, int, int]]:
+    """Return the top players in ``guild_id``."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.execute(
+            """
+            SELECT user_id, wins, losses
+            FROM rps_stats
+            WHERE guild_id = ?
+            ORDER BY wins DESC, losses ASC
+            LIMIT ?
+            """,
+            (guild_id, limit),
+        )
+        return cursor.fetchall()
+
+
+# Ensure database exists when module is imported
+init_db()


### PR DESCRIPTION
## Summary
- add SQLite-backed storage layer for rock-paper-scissors results
- track user wins/losses in the `rps` command
- provide new `rpsstats` command for user/server leaderboards

## Testing
- `python -m py_compile cogs/storage.py cogs/fun.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3038fbd388320b5616c0318ebb9da