### PR TITLE
feat: add per-guild prefix management

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 - My first discord bot.
 - Features multiple funcitonalities such as moderation commands, fun mini-games and actions.
 - Made in python!
+
+## Prefix configuration
+
+Syaa supports a per-guild command prefix stored in a local SQLite database.  Use
+the following slash commands to manage it:
+
+- `/prefix` - show the current prefix for the guild
+- `/setprefix <prefix>` - set a custom prefix (administrator only)
+- `/resetprefix` - remove the custom prefix and revert to the default `!`

--- a/main.py
+++ b/main.py
@@ -9,7 +9,9 @@ before the bot connects to Discord.
 from __future__ import annotations
 
 import os
+import sqlite3
 import discord
+from discord import app_commands
 from discord.ext import commands
 from dotenv import load_dotenv
 
@@ -20,7 +22,47 @@ from dotenv import load_dotenv
 
 load_dotenv()  # Load environment variables from .env file
 TOKEN = os.getenv("DISCORD_TOKEN")
+
+# ---------------------------------------------------------------------------
+# Prefix handling
+# ---------------------------------------------------------------------------
+
+DB_PATH = "guild_prefixes.db"
 DEFAULT_PREFIX = "!"
+
+# Ensure the database and table exist
+with sqlite3.connect(DB_PATH) as conn:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS guild_prefixes (
+            guild_id INTEGER PRIMARY KEY,
+            prefix   TEXT NOT NULL
+        )
+        """
+    )
+
+
+def _get_guild_prefix(guild_id: int | None) -> str:
+    """Return the stored prefix for ``guild_id`` or ``DEFAULT_PREFIX``."""
+
+    if guild_id is None:
+        return DEFAULT_PREFIX
+
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT prefix FROM guild_prefixes WHERE guild_id = ?", (guild_id,)
+        )
+        row = cur.fetchone()
+
+    return row[0] if row else DEFAULT_PREFIX
+
+
+def get_prefix(bot: commands.Bot, message: discord.Message) -> list[str]:
+    """Return the prefix list for the current guild."""
+
+    prefix = _get_guild_prefix(message.guild.id if message.guild else None)
+    return commands.when_mentioned_or(prefix)(bot, message)
 
 
 class SyaaBot(commands.Bot):
@@ -28,10 +70,7 @@ class SyaaBot(commands.Bot):
 
     def __init__(self) -> None:
         intents = discord.Intents.all()
-        super().__init__(
-            command_prefix=commands.when_mentioned_or(DEFAULT_PREFIX),
-            intents=intents,
-        )
+        super().__init__(command_prefix=get_prefix, intents=intents)
 
     async def setup_hook(self) -> None:
         """Load extensions and sync the application command tree."""
@@ -69,8 +108,42 @@ async def on_ready() -> None:
 async def prefix(interaction: discord.Interaction) -> None:
     """Slash command to display the configured prefix."""
 
+    current = _get_guild_prefix(interaction.guild_id)
     await interaction.response.send_message(
-        f"The current bot prefix is: {DEFAULT_PREFIX}"
+        f"The current bot prefix is: {current}"
+    )
+
+
+@bot.tree.command(description="Set the bot prefix for this guild")
+@app_commands.checks.has_permissions(administrator=True)
+@app_commands.describe(prefix="The new prefix to use")
+async def setprefix(interaction: discord.Interaction, prefix: str) -> None:
+    """Slash command to store a new guild prefix."""
+
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "REPLACE INTO guild_prefixes (guild_id, prefix) VALUES (?, ?)",
+            (interaction.guild_id, prefix),
+        )
+        conn.commit()
+
+    await interaction.response.send_message(f"Prefix set to: {prefix}")
+
+
+@bot.tree.command(description="Reset the bot prefix for this guild")
+@app_commands.checks.has_permissions(administrator=True)
+async def resetprefix(interaction: discord.Interaction) -> None:
+    """Remove any custom prefix for this guild."""
+
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "DELETE FROM guild_prefixes WHERE guild_id = ?",
+            (interaction.guild_id,),
+        )
+        conn.commit()
+
+    await interaction.response.send_message(
+        f"Prefix reset to: {DEFAULT_PREFIX}"
     )
 
 


### PR DESCRIPTION
## Summary
- store per-guild prefixes in SQLite
- allow admins to set and reset a guild's prefix
- document prefix configuration

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a303982f008320bae17e4b21e111cb