### PR TITLE
Add TicTacToe game with persistent stats

### DIFF
--- a/cogs/storage.py
+++ b/cogs/storage.py
@@ -1,4 +1,4 @@
-"""Simple storage layer for RPS stats using SQLite."""
+"""Simple storage layer for game stats using SQLite."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ DB_PATH = Path(__file__).with_name("rps_stats.sqlite3")
 def init_db() -> None:
     """Initialise the database if it doesn't exist."""
     with sqlite3.connect(DB_PATH) as conn:
+        # RPS statistics table
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS rps_stats (
@@ -23,6 +24,20 @@ def init_db() -> None:
             )
             """
         )
+
+        # TicTacToe statistics table
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tictactoe_stats (
+                guild_id INTEGER,
+                user_id INTEGER,
+                wins INTEGER DEFAULT 0,
+                losses INTEGER DEFAULT 0,
+                PRIMARY KEY (guild_id, user_id)
+            )
+            """
+        )
+
         conn.commit()
 
 
@@ -74,6 +89,65 @@ def get_leaderboard(guild_id: int, limit: int = 10) -> List[Tuple[int, int, int]
             """
             SELECT user_id, wins, losses
             FROM rps_stats
+            WHERE guild_id = ?
+            ORDER BY wins DESC, losses ASC
+            LIMIT ?
+            """,
+            (guild_id, limit),
+        )
+        return cursor.fetchall()
+
+
+def record_tictactoe_win(guild_id: int, user_id: int) -> None:
+    """Record a TicTacToe win for the given user."""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            """
+            INSERT INTO tictactoe_stats (guild_id, user_id, wins, losses)
+            VALUES (?, ?, 1, 0)
+            ON CONFLICT(guild_id, user_id)
+            DO UPDATE SET wins = wins + 1
+            """,
+            (guild_id, user_id),
+        )
+        conn.commit()
+
+
+def record_tictactoe_loss(guild_id: int, user_id: int) -> None:
+    """Record a TicTacToe loss for the given user."""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            """
+            INSERT INTO tictactoe_stats (guild_id, user_id, wins, losses)
+            VALUES (?, ?, 0, 1)
+            ON CONFLICT(guild_id, user_id)
+            DO UPDATE SET losses = losses + 1
+            """,
+            (guild_id, user_id),
+        )
+        conn.commit()
+
+
+def get_tictactoe_user_stats(guild_id: int, user_id: int) -> Tuple[int, int]:
+    """Return TicTacToe wins and losses for ``user_id`` in ``guild_id``."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.execute(
+            "SELECT wins, losses FROM tictactoe_stats WHERE guild_id = ? AND user_id = ?",
+            (guild_id, user_id),
+        )
+        row = cursor.fetchone()
+        return (row[0], row[1]) if row else (0, 0)
+
+
+def get_tictactoe_leaderboard(
+    guild_id: int, limit: int = 10
+) -> List[Tuple[int, int, int]]:
+    """Return the top TicTacToe players in ``guild_id``."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.execute(
+            """
+            SELECT user_id, wins, losses
+            FROM tictactoe_stats
             WHERE guild_id = ?
             ORDER BY wins DESC, losses ASC
             LIMIT ?

--- a/cogs/tictactoe.py
+++ b/cogs/tictactoe.py
@@ -1,0 +1,154 @@
+"""TicTacToe game cog."""
+
+from __future__ import annotations
+
+import discord
+from discord.ext import commands
+
+from .storage import (
+    record_tictactoe_win,
+    record_tictactoe_loss,
+    get_tictactoe_user_stats,
+    get_tictactoe_leaderboard,
+)
+
+
+class TicTacToeButton(discord.ui.Button):
+    def __init__(self, x: int, y: int) -> None:
+        super().__init__(style=discord.ButtonStyle.secondary, label=" ", row=y)
+        self.x = x
+        self.y = y
+
+    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        view: TicTacToeView = self.view  # type: ignore[assignment]
+        await view.handle_move(interaction, self)
+
+
+class TicTacToeView(discord.ui.View):
+    def __init__(self, player1: discord.Member, player2: discord.Member) -> None:
+        super().__init__(timeout=180)
+        self.players = (player1, player2)
+        self.current = 0
+        self.board = [["" for _ in range(3)] for _ in range(3)]
+        for y in range(3):
+            for x in range(3):
+                self.add_item(TicTacToeButton(x, y))
+
+    async def handle_move(
+        self, interaction: discord.Interaction, button: TicTacToeButton
+    ) -> None:
+        if interaction.user not in self.players:
+            await interaction.response.send_message(
+                "You're not playing this game.", ephemeral=True
+            )
+            return
+
+        if interaction.user != self.players[self.current]:
+            await interaction.response.send_message("It's not your turn!", ephemeral=True)
+            return
+
+        if self.board[button.y][button.x]:
+            await interaction.response.send_message(
+                "That spot is already taken.", ephemeral=True
+            )
+            return
+
+        mark = "X" if self.current == 0 else "O"
+        button.label = mark
+        button.style = (
+            discord.ButtonStyle.danger if self.current == 0 else discord.ButtonStyle.success
+        )
+        button.disabled = True
+        self.board[button.y][button.x] = mark
+
+        winner = self.check_winner()
+        embed = discord.Embed(title="Tic Tac Toe")
+        guild_id = interaction.guild.id if interaction.guild else 0
+
+        if winner is not None:
+            for child in self.children:
+                child.disabled = True
+            winner_member = self.players[winner]
+            loser_member = self.players[winner ^ 1]
+            embed.description = f"{winner_member.mention} wins!"
+            record_tictactoe_win(guild_id, winner_member.id)
+            record_tictactoe_loss(guild_id, loser_member.id)
+            self.stop()
+        elif self.is_draw():
+            for child in self.children:
+                child.disabled = True
+            embed.description = "It's a draw!"
+            self.stop()
+        else:
+            self.current ^= 1
+            embed.description = f"It's {self.players[self.current].mention}'s turn."
+
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    def check_winner(self) -> int | None:
+        lines = []
+        lines.extend(self.board)
+        lines.extend([[self.board[y][x] for y in range(3)] for x in range(3)])
+        lines.append([self.board[i][i] for i in range(3)])
+        lines.append([self.board[i][2 - i] for i in range(3)])
+
+        for line in lines:
+            if line[0] and line.count(line[0]) == 3:
+                return 0 if line[0] == "X" else 1
+        return None
+
+    def is_draw(self) -> bool:
+        return all(cell for row in self.board for cell in row)
+
+
+class TicTacToe(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.hybrid_command(description="Challenge another user to Tic Tac Toe")
+    async def tictactoe(self, ctx: commands.Context, opponent: discord.Member) -> None:
+        if opponent == ctx.author or opponent.bot:
+            await ctx.send("Please challenge someone else!")
+            return
+
+        view = TicTacToeView(ctx.author, opponent)
+        embed = discord.Embed(
+            title="Tic Tac Toe",
+            description=(
+                f"{ctx.author.mention} vs {opponent.mention}\n"
+                f"{ctx.author.mention} goes first."
+            ),
+        )
+        await ctx.send(embed=embed, view=view)
+
+    @commands.hybrid_command(
+        description="Show Tic Tac Toe stats for a user or this server's leaderboard"
+    )
+    async def tictactoestats(
+        self, ctx: commands.Context, member: discord.Member | None = None
+    ) -> None:
+        guild_id = ctx.guild.id if ctx.guild else 0
+
+        if member is not None:
+            wins, losses = get_tictactoe_user_stats(guild_id, member.id)
+            await ctx.send(
+                f"{member.display_name} has {wins} wins and {losses} losses in Tic Tac Toe."
+            )
+            return
+
+        leaderboard = get_tictactoe_leaderboard(guild_id)
+        if not leaderboard:
+            await ctx.send("No Tic Tac Toe games have been played yet!")
+            return
+
+        lines = []
+        for index, (user_id, wins, losses) in enumerate(leaderboard, start=1):
+            user = ctx.guild.get_member(user_id) if ctx.guild else self.bot.get_user(user_id)
+            name = user.display_name if user else f"User {user_id}"
+            lines.append(f"{index}. {name} - {wins}W/{losses}L")
+
+        await ctx.send("Tic Tac Toe Leaderboard:\n" + "\n".join(lines))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(TicTacToe(bot))

--- a/main.py
+++ b/main.py
@@ -51,6 +51,7 @@ class SyaaBot(commands.Bot):
             "cogs.fun",
             "cogs.moderation",
             "cogs.actions",
+            "cogs.tictactoe",
         ]:
             try:
                 await self.load_extension(extension)


### PR DESCRIPTION
## Summary
- add interactive TicTacToe game using buttons
- track TicTacToe wins/losses in SQLite storage
- expose `/tictactoestats` command and load extension

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a31a5390c483208be2bbf141b0c7b9