### PR TITLE
Expose traceback in command errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import logging
 import os
+import traceback
+
 import discord
 from discord.ext import commands
 from dotenv import load_dotenv
@@ -77,7 +79,10 @@ class SyaaBot(commands.Bot):
             getattr(ctx.command, "name", "unknown"),
             exc_info=error,
         )
-        await ctx.send("An unexpected error occurred. Please try again later.")
+        tb = "".join(
+            traceback.format_exception(type(error), error, error.__traceback__)
+        )
+        await ctx.send(f"```py\n{tb}\n```")
 
 
 bot = SyaaBot()


### PR DESCRIPTION
## Summary
- show formatted traceback for unhandled command errors

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a336a0d76083208e60ce4dbc2b441f