### PR TITLE
Add Hangman game and stats

### DIFF
--- a/cogs/hangman.py
+++ b/cogs/hangman.py
@@ -1,0 +1,137 @@
+"""Hangman game cog."""
+
+from __future__ import annotations
+
+import random
+import string
+
+import discord
+from discord.ext import commands
+
+from .storage import record_hangman_win, record_hangman_loss
+
+WORDS = [
+    "python",
+    "discord",
+    "hangman",
+    "bot",
+    "cog",
+    "extension",
+    "asyncio",
+    "database",
+]
+
+
+class HangmanButton(discord.ui.Button):
+    def __init__(self, letter: str) -> None:
+        index = string.ascii_lowercase.index(letter)
+        super().__init__(
+            label=letter.upper(),
+            style=discord.ButtonStyle.secondary,
+            row=index // 5,
+        )
+        self.letter = letter
+
+    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        view: HangmanView = self.view  # type: ignore[assignment]
+        await view.handle_guess(interaction, self)
+
+
+class HangmanView(discord.ui.View):
+    def __init__(self, players: list[discord.Member], word: str) -> None:
+        super().__init__(timeout=180)
+        self.players = players
+        self.word = word
+        self.progress = ["_" if c.isalpha() else c for c in word]
+        self.misses = 0
+        self.max_misses = 6
+
+        for letter in string.ascii_lowercase:
+            self.add_item(HangmanButton(letter))
+
+    def format_status(self) -> str:
+        return (
+            f"Word: {' '.join(self.progress)}\n"
+            f"Misses: {self.misses}/{self.max_misses}"
+        )
+
+    async def handle_guess(self, interaction: discord.Interaction, button: HangmanButton) -> None:
+        if interaction.user not in self.players:
+            await interaction.response.send_message(
+                "You're not playing this game.", ephemeral=True
+            )
+            return
+
+        button.disabled = True
+        letter = button.letter
+        finished: str | None = None
+
+        if letter in self.word:
+            for idx, char in enumerate(self.word):
+                if char == letter:
+                    self.progress[idx] = char
+            if "_" not in self.progress:
+                finished = "win"
+        else:
+            self.misses += 1
+            button.style = discord.ButtonStyle.danger
+            if self.misses >= self.max_misses:
+                finished = "loss"
+
+        guild_id = interaction.guild.id if interaction.guild else 0
+
+        if finished == "win":
+            for child in self.children:
+                child.disabled = True
+            for player in self.players:
+                await record_hangman_win(guild_id, player.id)
+            description = (
+                f"{' and '.join(p.mention for p in self.players)} guessed the word "
+                f"**{self.word}**!"
+            )
+            embed = discord.Embed(title="Hangman", description=description)
+            await interaction.response.edit_message(embed=embed, view=self)
+            self.stop()
+            return
+
+        if finished == "loss":
+            for child in self.children:
+                child.disabled = True
+            for player in self.players:
+                await record_hangman_loss(guild_id, player.id)
+            description = f"No more guesses! The word was **{self.word}**."
+            embed = discord.Embed(title="Hangman", description=description)
+            await interaction.response.edit_message(embed=embed, view=self)
+            self.stop()
+            return
+
+        embed = discord.Embed(title="Hangman", description=self.format_status())
+        await interaction.response.edit_message(embed=embed, view=self)
+
+
+class Hangman(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.hybrid_command(description="Play a game of Hangman")
+    async def hangman(self, ctx: commands.Context, opponent: discord.Member | None = None) -> None:
+        players = [ctx.author]
+        if opponent is not None:
+            if opponent == ctx.author or opponent.bot:
+                await ctx.send("Please challenge someone else!")
+                return
+            players.append(opponent)
+
+        word = random.choice(WORDS)
+        view = HangmanView(players, word)
+        embed = discord.Embed(
+            title="Hangman",
+            description=(
+                f"Players: {' and '.join(p.mention for p in players)}\n" + view.format_status()
+            ),
+        )
+        await ctx.send(embed=embed, view=view)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Hangman(bot))

--- a/cogs/storage.py
+++ b/cogs/storage.py
@@ -39,6 +39,19 @@ def init_db() -> None:
             """
         )
 
+        # Hangman statistics table
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS hangman_stats (
+                guild_id INTEGER,
+                user_id INTEGER,
+                wins INTEGER DEFAULT 0,
+                losses INTEGER DEFAULT 0,
+                PRIMARY KEY (guild_id, user_id)
+            )
+            """
+        )
+
         conn.commit()
 
 
@@ -163,6 +176,81 @@ async def get_tictactoe_leaderboard(
                 """
                 SELECT user_id, wins, losses
                 FROM tictactoe_stats
+                WHERE guild_id = ?
+                ORDER BY wins DESC, losses ASC
+                LIMIT ?
+                """,
+                (guild_id, limit),
+            )
+            return cursor.fetchall()
+
+    return await asyncio.to_thread(task)
+
+
+async def record_hangman_win(guild_id: int, user_id: int) -> None:
+    """Record a Hangman win for the given user without blocking."""
+
+    def task() -> None:
+        with sqlite3.connect(DB_PATH) as conn:
+            conn.execute(
+                """
+                INSERT INTO hangman_stats (guild_id, user_id, wins, losses)
+                VALUES (?, ?, 1, 0)
+                ON CONFLICT(guild_id, user_id)
+                DO UPDATE SET wins = wins + 1
+                """,
+                (guild_id, user_id),
+            )
+            conn.commit()
+
+    await asyncio.to_thread(task)
+
+
+async def record_hangman_loss(guild_id: int, user_id: int) -> None:
+    """Record a Hangman loss for the given user without blocking."""
+
+    def task() -> None:
+        with sqlite3.connect(DB_PATH) as conn:
+            conn.execute(
+                """
+                INSERT INTO hangman_stats (guild_id, user_id, wins, losses)
+                VALUES (?, ?, 0, 1)
+                ON CONFLICT(guild_id, user_id)
+                DO UPDATE SET losses = losses + 1
+                """,
+                (guild_id, user_id),
+            )
+            conn.commit()
+
+    await asyncio.to_thread(task)
+
+
+async def get_hangman_user_stats(guild_id: int, user_id: int) -> Tuple[int, int]:
+    """Return Hangman wins and losses for ``user_id`` in ``guild_id`` without blocking."""
+
+    def task() -> Tuple[int, int]:
+        with sqlite3.connect(DB_PATH) as conn:
+            cursor = conn.execute(
+                "SELECT wins, losses FROM hangman_stats WHERE guild_id = ? AND user_id = ?",
+                (guild_id, user_id),
+            )
+            row = cursor.fetchone()
+            return (row[0], row[1]) if row else (0, 0)
+
+    return await asyncio.to_thread(task)
+
+
+async def get_hangman_leaderboard(
+    guild_id: int, limit: int = 10
+) -> List[Tuple[int, int, int]]:
+    """Return the top Hangman players in ``guild_id`` without blocking."""
+
+    def task() -> List[Tuple[int, int, int]]:
+        with sqlite3.connect(DB_PATH) as conn:
+            cursor = conn.execute(
+                """
+                SELECT user_id, wins, losses
+                FROM hangman_stats
                 WHERE guild_id = ?
                 ORDER BY wins DESC, losses ASC
                 LIMIT ?

--- a/main.py
+++ b/main.py
@@ -55,6 +55,7 @@ class SyaaBot(commands.Bot):
             "cogs.moderation",
             "cogs.actions",
             "cogs.tictactoe",
+            "cogs.hangman",
         ]:
             try:
                 await self.load_extension(extension)


### PR DESCRIPTION
## Summary
- Implement interactive Hangman game with optional opponent support.
- Track Hangman wins and losses in storage backend.
- Load Hangman cog during bot startup.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a3427e27b4832086ddcf407fe7a3d0